### PR TITLE
Update Fn.concat to compose a function

### DIFF
--- a/monoid.js
+++ b/monoid.js
@@ -69,7 +69,7 @@ const Fn = f =>
 ({
   fold: f,
   concat: o =>
-    Fn(x => f(x).concat(o.fold(x))),
+    Fn(x => f(o.fold(x))),
   inspect: () => `Fn(${f})`
 })
 


### PR DESCRIPTION
Love the series and came on here to clone the spotify example. I saw there was an issue related and thought I'd try to help: https://github.com/DrBoolean/spotify-fp-example/issues/1

The Fn.concat is assuming that the function will return another Fn but it's usage (where fork is just calling the function) highlights that this is probably not intentional. This fix composes the functions together when concatenating.